### PR TITLE
Remove outdated sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,7 @@ Other models are more focused on the community, where members of the community p
 - [`Patreon`](https://www.patreon.com/)
 - [`OpenCollective`](https://opencollective.com/)
 - [`Bountysource`](https://www.bountysource.com/)
-- [`CodeFund`](https://codefund.io/)
 - [`Liberapay`](https://en.liberapay.com/)
-- [`LibreSelery`](https://github.com/protontypes/libreselery)
 - [`GitHub Sponsors`](https://github.com/sponsors)
 
 ## Links


### PR DESCRIPTION
Codefund is 404, repository archived:

![image](https://github.com/ralphtheninja/open-funding/assets/1366654/3d3702cb-0b2d-41e2-b8fc-7cc84937d150)

https://github.com/gitcoinco/code_fund_ads (linked from https://github.com/gitcoinco/codefund)

---

LibreSelery is archived:

![image](https://github.com/ralphtheninja/open-funding/assets/1366654/a5e16d67-65cd-4c4e-b2a5-9eab245765a6)

https://github.com/Ly0n/LibreSelery