### PR TITLE
remove numfocus as only tightly affiliated projects are elegible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2070,26 +2070,6 @@ N/A
 
 ---
 
-### [`Numfocus`](https://numfocus.org/)
-
-#### About
-
-The Small Development Grants program is a NumFOCUS microgrant program benefitting our Sponsored and Affiliated projects. The program helps projects fund important work that they might not otherwise be able to do like improving usability, growing project communities, and speeding up the time to major releases.
-
-#### Eligibility Criteria
-
-Any NumFOCUS Fiscally Sponsored or Affiliated project is eligible to submit 1 proposal per grant cycle. Each project may receive a maximum of 2 grants per calendar year.
-
-#### Application
-
-N/A
-
-#### Deadline
-
-N/A
-
----
-
 ### [`Beta Nsf Gov`](https://beta.nsf.gov/funding/opportunities/cns-computer-systems-research-csr)
 
 #### About


### PR DESCRIPTION
you need to be "NumFOCUS Fiscally Sponsored or Affiliated project" to apply

and in such case you surely know about such program?

(and even if NumFOCUS is failing to communicate it to their "Fiscally Sponsored or Affiliated" projects it is not our role to do their job for them)