### PR TITLE
remove Facebook Research Grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1520,26 +1520,6 @@ mid August 2024
 
 ---
 
-### [`Facebook Research Grants`](https://research.facebook.com/research-awards/#all-the-latest--research-awards---status--open---)
-
-#### About
-
-N/A
-
-#### Eligibility Criteria
-
-N/A
-
-#### Application
-
-"There are no open RFPs at this time. Please check back later." as of 2024-08-30
-
-#### Deadline
-
-N/A
-
----
-
 ### [`Sage Concept Grants`](https://ocean.sagepub.com/concept-grants/)
 
 #### About


### PR DESCRIPTION
mentions academic rather than open source, has no open grants and had none for some time

fixes #110