### PR TITLE
mark private fiat projects to make skipping them easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ N/A
 
 #### About
 
+Grant for subset of cryptocurrency topic.
+
 The Gitcoin Grants Program is a quarterly initiative run by Gitcoin DAO that empowers everyday believers in web3 to drive funding toward what they believe matters, with the impact of individual donations being magnified by the use of the Quadratic Funding (QF) distribution mechanism. QF was introduced in a paper published in 2018 by Vitalik Buterin, Zoe Hitzig, and Glen Weyl.
 
 #### Eligibility Criteria


### PR DESCRIPTION
I propose to add "Grant for subset of cryptocurrency topic." or similar at start of description of each cryptocurrency-related grant to allow easy skipping of them.

This is probing PR and I have done it for one project, if accepted I would do the same for more (maybe even without PR)

See #64

Personally I have temptation to remove them all altogether, not just scammy/suspicious ones but then you have no clear border what else should be ejected so I am scared to start such censorship process.

But I think that clearly describing them would be OK, as many people are not going to be interested in them.