### PR TITLE
remove rubycentral

### DIFF
--- a/README.md
+++ b/README.md
@@ -1913,24 +1913,6 @@ May 2 2023.
 
 ---
 
-### [`Rubycentral`](https://rubycentral.org/)
-
-#### About
-
-#### Eligibility Criteria
-
-N/A
-
-#### Application
-
-N/A
-
-#### Deadline
-
-N/A
-
----
-
 ### [`Wikimedia Grants`](https://meta.wikimedia.org/wiki/Grants:Start)
 
 #### About


### PR DESCRIPTION
I see no way to apply

They support some core Ruby projects but I see no sign of grant program